### PR TITLE
Make Python/PySys detection more reliable

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,7 +61,7 @@ async function getPysysInterpreter(logger: vscode.OutputChannel): Promise<string
 
 	//however if there is a config entry for interpreter_path then we want to use this 
 	const override_cmd = vscode.workspace.getConfiguration("pysys").get("interpreter_path","na");
-	if (override_cmd !== "na") {
+	if (override_cmd !== "na" && override_cmd !== "") {
 		cmds = [override_cmd];
 	}
 
@@ -72,10 +72,10 @@ async function getPysysInterpreter(logger: vscode.OutputChannel): Promise<string
 			let versionOutput: any = await versionCmd.run(".",[]);
 
 			let version: string = "";
-			if( versionOutput.stdout.indexOf("ersion") >= 0) {
+			if( versionOutput.stdout.indexOf("ersion") >= 0 || versionOutput.stdout.indexOf("ython") >= 0) {
 				version = versionOutput.stdout.match(/([.-9])+/g)[0];
 
-			} else if (versionOutput.stderr.indexOf("ersion") >= 0) {
+			} else if (versionOutput.stderr.indexOf("ersion") >= 0 || versionOutput.stdout.indexOf("ython") >= 0) {
 				version = versionOutput.stderr.match(/([.-9])+/g)[0];
 			}
 


### PR DESCRIPTION
Hey John, here's my attempt to fix an issue (#22) I hit using the plugin with a remote WSL2 Ubuntu 18.04 environment, where it failed to find a Python installation despite there being at least two of them on the path. There were two different problems:

1. All the Pythons I have print `Python x.y.z` in response to `-V` so we probably need to look for `ython` as well as `ersion` in the output.
2. The `get("interpreter_path","na")` was returning an empty string rather than `na`. No idea why, but I bodged in a check for that anyway.

It seems to work for me now but given that my knowledge of TypeScript is near-zero and of VS Code extensions even less, I have probably missed the real problem and/or implemented the fix in a horrible way.  Hopefully this is some use regardless.

Cheers,

Scott